### PR TITLE
Fix input focus color and icon flicker on theme change

### DIFF
--- a/client/src/components/AuthForm.module.css
+++ b/client/src/components/AuthForm.module.css
@@ -20,6 +20,7 @@
     border-radius: 0.5rem;
     background: var(--color-surface);
     color: var(--color-text);
+    caret-color: var(--color-text);
   }
 
 .inputWrap {
@@ -39,10 +40,18 @@
     background: none;
     border: none;
     cursor: pointer;
+    color: var(--color-text-muted);
+    transition: none;
   }
 
+  /* Make sure SVG icons inherit and don't animate, preventing flicker */
+  .togglePass svg { display: block; color: inherit; fill: none; stroke: currentColor; transition: none; }
+  .togglePass:hover { color: var(--color-text); }
+
 .label { display: block; font-size: 0.875rem; font-weight: 500; color: var(--color-text); margin-bottom: 0.25rem; }
-.input:focus { outline: none; box-shadow: 0 0 0 2px rgba(37,99,235,0.35); border-color: transparent; }
+.input:focus { outline: none; box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-primary) 35%, transparent); border-color: var(--color-primary); background: var(--color-surface); color: var(--color-text); }
+/* Ensure focus ring looks good in dark too */
+.dark .input:focus { box-shadow: 0 0 0 2px color-mix(in oklab, var(--color-primary) 55%, transparent); }
 .errorText { margin-top: 0.25rem; font-size: 0.875rem; color: #ef4444; }
 .submit { width: 100%; display: flex; justify-content: center; padding: 0.75rem 1rem; border: 1px solid transparent; font-weight: 600; border-radius: 0.5rem; color: #fff; background: var(--color-primary); box-shadow: 0 1px 2px rgba(0,0,0,0.1); }
 .submit:hover { background: var(--color-primary-700); }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -60,8 +60,14 @@
 @layer base {
   /* Smooth transitions */
   * {
-  transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out, color 0.2s ease-in-out;
+  transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
   }
+  /* Avoid color/background transitions on theme toggle to prevent flicker */
+  html.dark *, html:not(.dark) * {
+    transition-property: border-color, box-shadow;
+  }
+  /* Keep icons stable */
+  svg, svg * { transition: none !important; }
 
   /* Base */
   html {


### PR DESCRIPTION
Fix incorrect input focus color and eye icon flicker when changing themes.

---
<a href="https://cursor.com/background-agent?bcId=bc-20e948e5-a53a-47c6-94c0-3a4d219b1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20e948e5-a53a-47c6-94c0-3a4d219b1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

