### PR TITLE
Fix mobile keyboard scroll bug

### DIFF
--- a/client/src/components/App.module.css
+++ b/client/src/components/App.module.css
@@ -1,5 +1,6 @@
 .root {
-	height: calc(var(--vh, 1vh) * 98);
+	box-sizing: border-box;
+	height: 100%;
 	display: flex;
 	position: relative;
 	padding-top: env(safe-area-inset-top);
@@ -19,11 +20,12 @@
 }
 
 .mobilePage {
+	box-sizing: border-box;
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	height: calc(var(--vh, 1vh) * 98);
+	height: 100%;
 	overflow: hidden;
 }
 

--- a/client/src/components/ChatWindow.module.css
+++ b/client/src/components/ChatWindow.module.css
@@ -43,7 +43,7 @@
 .mobileOnly { display: inline-flex; }
 @media (min-width: 1024px) { .mobileOnly { display: none; } }
 
-.messages { flex: 1; overflow: auto; padding: 0.5rem 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; -webkit-overflow-scrolling: touch; }
+.messages { flex: 1; overflow: auto; padding: 0.5rem 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; -webkit-overflow-scrolling: touch; overscroll-behavior: contain; }
 @media (min-width: 640px) { .messages { gap: 1rem; padding: 1rem; } }
 .empty { text-align: center; color: var(--color-text-muted); margin-top: 2rem; padding: 0 1rem; }
 .emptyInner { text-align: center; padding: 1rem; }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -86,8 +86,8 @@
   }
 
   /* When keyboard opens, avoid document scroll jumps; page compresses instead */
-  html, body { height: calc(var(--vh, 1vh) * 100); }
-  .keyboard-open { position: fixed; width: 100%; }
+  html, body { height: calc(var(--vh, 1vh) * 100); height: 100dvh; }
+  body.keyboard-open { position: fixed; left: 0; right: 0; top: 0; width: 100%; }
 
   /* Form control base reset tuned for theming */
   :where(input, textarea, select, button) {

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,16 +8,17 @@ import { ThemeProvider } from './components/ui/ThemeProvider'
 // Handle mobile keyboard: toggle body class to prevent whole-document scrolling
 if (typeof window !== 'undefined' && 'visualViewport' in window) {
   const vv = (window as any).visualViewport as VisualViewport;
-  const root = document.documentElement;
+  const body = document.body;
   const onResize = () => {
     const height = vv.height;
-    const fullHeight = window.innerHeight; // may include UI chrome
-    // Heuristic: if viewport reduced notably, keyboard likely open
-    const keyboardOpen = fullHeight - height > 120; // px threshold
-    root.classList.toggle('keyboard-open', keyboardOpen);
+    const fullHeight = window.innerHeight;
+    const keyboardOpen = fullHeight - height > 120;
+    body.classList.toggle('keyboard-open', keyboardOpen);
   };
   vv.addEventListener('resize', onResize);
+  vv.addEventListener('scroll', onResize);
   window.addEventListener('resize', onResize);
+  onResize();
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
Fix mobile page scroll on keyboard open by using `100dvh` and `body` scroll lock.

Mobile browsers often scroll the page when the virtual keyboard appears, even with `overflow: hidden`, due to viewport resizing. This PR implements `100dvh` with a `--vh` fallback for accurate height, locks the `body` with `position: fixed` when the keyboard is detected, and ensures internal containers handle their own scrolling, preventing unwanted document shifts.

---
<a href="https://cursor.com/background-agent?bcId=bc-eefb429c-ed3c-4cba-86b1-b175a8a3fe8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eefb429c-ed3c-4cba-86b1-b175a8a3fe8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

