### PR TITLE
Fix input overlap in browser and chat

### DIFF
--- a/client/src/components/App.module.css
+++ b/client/src/components/App.module.css
@@ -67,10 +67,10 @@
 }
 
 .statusWrap {
-	position: fixed;
-	top: 1rem;
-	right: 1rem;
-	z-index: 20;
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 20;
 }
 
 .statusDot {
@@ -82,8 +82,11 @@
 .online { background: #22c55e; }
 .offline { background: #ef4444; }
 
-/* Nudge status dot up on small screens to avoid FAB overlap */
+/* On small screens, anchor to bottom without conflicting with top */
 @media (max-width: 1023.98px) {
-	.statusWrap { bottom: 4.75rem; }
+  .statusWrap {
+    top: auto;
+    bottom: calc(1rem + env(safe-area-inset-bottom));
+  }
 }
 

--- a/client/src/components/ChatWindow.module.css
+++ b/client/src/components/ChatWindow.module.css
@@ -45,12 +45,12 @@
 .mobileOnly { display: inline-flex; }
 @media (min-width: 1024px) { .mobileOnly { display: none; } }
 
-.messages { flex: 1 1 auto;; min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 0.5rem 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; -webkit-overflow-scrolling: touch; }
+.messages { flex: 1 1 auto;; min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 0.5rem 0.5rem; display: flex; flex-direction: column; gap: 0.5rem; -webkit-overflow-scrolling: touch; scroll-padding-bottom: 4.5rem; }
 @media (min-width: 640px) { .messages { gap: 1rem; padding: 1rem; } }
 .empty { text-align: center; color: var(--color-text-muted); margin-top: 2rem; padding: 0 1rem; }
 .emptyInner { text-align: center; padding: 1rem; }
 
-.inputBar { padding: 0.5rem; padding-bottom: calc(0.5rem + env(safe-area-inset-bottom)); border-top: 1px solid var(--color-border); background: var(--color-surface-strong); flex-shrink: 0; backdrop-filter: blur(8px); }
+.inputBar { padding: 0.5rem; padding-bottom: calc(0.5rem + env(safe-area-inset-bottom)); border-top: 1px solid var(--color-border); background: var(--color-surface-strong); flex-shrink: 0; backdrop-filter: blur(8px); position: sticky; bottom: 0; }
 .form { display: flex; gap: 0.5rem; }
 .textInput { flex: 1; padding: 0 0.5rem; border: 1px solid var(--color-border); border-radius: 0.5rem; background: var(--color-surface); color: var(--color-text); }
 .textInput:focus { outline: none; box-shadow: 0 0 0 2px rgba(37,99,235,0.35); border-color: transparent; }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -107,10 +107,8 @@
      Lock layout when keyboard opens to prevent page-level scrolling. */
   html,
   body {
-    height: 100dvh;
-    height: 100svh;
-    height: 100lvh;
-    height: calc(var(--vh, 1vh) * 100);
+    /* Do not lock viewport height on the page itself */
+    height: auto;
   }
   #root {
     height: 100%;
@@ -260,6 +258,10 @@ body {
 #root {
   display: flex;
   flex-direction: column;
-  min-height: 100vh; /* или 100dvh/--vh для современных браузеров */
+  /* Use dynamic viewport height for correct keyboard/browser chrome behavior */
+  min-height: 100dvh;
+  min-height: 100svh;
+  min-height: 100lvh;
+  min-height: calc(var(--vh, 1vh) * 100);
   overflow: hidden; /* основной контейнер не скроллится */
 }


### PR DESCRIPTION
Fix UI overlaps in chat where the input covers the header and bottom input on mobile and browser.

This PR addresses issues where the input field would cover the header in the browser and the bottom chat input would be overlapped, particularly when the soft keyboard appeared.
Changes include:
- Using `100dvh` for the `#root` element to correctly handle dynamic viewport height changes.
- Repositioning the mobile status indicator to the bottom to prevent conflicts with the header and input.
- Making the chat input bar sticky and adding `scroll-padding-bottom` to the message list to ensure content is not obscured by the input.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddd154da-1775-47de-96f7-110173d5cca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddd154da-1775-47de-96f7-110173d5cca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

